### PR TITLE
Create a database recovery tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,14 @@ $ zigpy pcap fix-fcs input.pcap fixed.pcap
 $ # Fix a capture from stdin and send it to stdout
 $ bellows -d /dev/cu.GoControl_zigbee dump -w /dev/stdout | zigpy pcap fix-fcs - - | wireshark -k -S -i -
 ```
+
+# Database
+Attempt to recover a corrupted `zigbee.db` database:
+
+```console
+$ zigpy -v db recover broken.db fixed.db
+2022-05-07 13:01:22.907 host zigpy_cli.database ERROR Failed to insert INSERT INTO "attributes_cache_v7"("_rowid_", "ieee", "endpoint_id", "cluster", "attrid", "value") VALUES( 14507477, '00:15:8d:00:02:5e:f9:ff', 1, 1027, 0, 1001.78 );: IntegrityError('UNIQUE constraint failed: attributes_cache_v7.ieee, attributes_cache_v7.endpoint_id, attributes_cache_v7.cluster, attributes_cache_v7.attrid')
+2022-05-07 13:01:22.916 host zigpy_cli.database INFO Done
+```
+
+The final database will have no invalid constraints but data will likely be lost.

--- a/zigpy_cli/__main__.py
+++ b/zigpy_cli/__main__.py
@@ -1,4 +1,5 @@
 import zigpy_cli.ota  # noqa: F401
 import zigpy_cli.pcap  # noqa: F401
 import zigpy_cli.radio  # noqa: F401
+import zigpy_cli.database  # noqa: F401
 from zigpy_cli.cli import cli  # noqa: F401

--- a/zigpy_cli/database.py
+++ b/zigpy_cli/database.py
@@ -136,7 +136,7 @@ def recover(input_path, output_path):
             try:
                 cur.execute(statement)
             except sqlite3.IntegrityError as e:
-                LOGGER.error("Failed to insert %s: %r", statement, e)
+                LOGGER.warning("Skipping %s: %r", statement, e)
 
         # And finally commit
         for statement in ["PRAGMA writable_schema = off;", "COMMIT;"]:

--- a/zigpy_cli/database.py
+++ b/zigpy_cli/database.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+import pathlib
+import sqlite3
+import subprocess
+
+import click
+
+from zigpy_cli.cli import cli
+
+LOGGER = logging.getLogger(__name__)
+
+
+@cli.group()
+def db():
+    pass
+
+
+def sqlite3_split_statements(sql: str) -> list[str]:
+    """
+    Splits SQL into a list of statements.
+    """
+
+    statements = []
+    statement = ""
+
+    for chunk in sql.strip().split(";"):
+        if not chunk:
+            continue
+
+        statement += chunk + ";"
+
+        if sqlite3.complete_statement(statement):
+            statements.append(statement.strip())
+            statement = ""
+
+    if statement:
+        LOGGER.warning("Incomplete data remains after splitting SQL: %r", statement)
+
+    return statements
+
+
+def sqlite3_recover(path: pathlib.Path) -> str:
+    """
+    Recovers the contents of an SQLite database as valid SQL.
+    """
+
+    return subprocess.check_output(["sqlite3", str(path), ".recover"]).decode("utf-8")
+
+
+@db.command()
+@click.argument("input_path", type=click.Path(exists=True))
+@click.argument("output_path", type=click.Path())
+def recover(input_path, output_path):
+    if pathlib.Path(output_path).exists():
+        LOGGER.error("Output database already exists: %s", output_path)
+        return
+
+    # Fetch the user version, it isn't dumped by `.recover`
+    with sqlite3.connect(input_path) as conn:
+        cur = conn.cursor()
+        cur.execute("PRAGMA user_version")
+        (user_version,) = cur.fetchone()
+
+    sql = sqlite3_recover(input_path)
+    statements = sqlite3_split_statements(sql)
+
+    # Perform the `INSERT` statements separately
+    data_sql = []
+    schema_sql = [f"PRAGMA user_version={user_version};"]
+
+    for statement in statements:
+        if statement.startswith("INSERT"):
+            data_sql.append(statement)
+        else:
+            schema_sql.append(statement)
+
+    assert schema_sql[-2:] == ["PRAGMA writable_schema = off;", "COMMIT;"]
+
+    # Finally, perform the recovery
+    with sqlite3.connect(output_path) as conn:
+        cur = conn.cursor()
+
+        # First create the schema
+        for statement in schema_sql[:-2]:
+            LOGGER.debug("Schema: %s", statement)
+            cur.execute(statement)
+
+        # Then insert data, logging errors
+        for statement in data_sql:
+            LOGGER.debug("Data: %s", statement)
+
+            try:
+                cur.execute(statement)
+            except sqlite3.IntegrityError as e:
+                LOGGER.error("Failed to insert %s: %r", statement, e)
+
+        # And finally commit
+        for statement in ["PRAGMA writable_schema = off;", "COMMIT;"]:
+            LOGGER.debug("Postamble: %s", statement)
+            cur.execute(statement)
+
+    LOGGER.info("Done")

--- a/zigpy_cli/database.py
+++ b/zigpy_cli/database.py
@@ -124,6 +124,15 @@ def recover(input_path, output_path):
         for statement in data_sql:
             LOGGER.debug("Data: %s", statement)
 
+            # Ignore internal tables
+            if statement.startswith(
+                (
+                    'INSERT INTO "sqlite_sequence"(',
+                    "CREATE TABLE IF NOT EXISTS  sqlite_sequence(",
+                )
+            ):
+                continue
+
             try:
                 cur.execute(statement)
             except sqlite3.IntegrityError as e:

--- a/zigpy_cli/database.py
+++ b/zigpy_cli/database.py
@@ -25,11 +25,11 @@ def sqlite3_split_statements(sql: str) -> list[str]:
     statements = []
     statement = ""
 
-    for chunk in sql.strip().split(";"):
-        if not chunk:
-            continue
+    chunks = sql.strip().split(";")
+    chunks_with_delimiter = [s + ";" for s in chunks[:-1]] + [chunks[-1]]
 
-        statement += chunk + ";"
+    for chunk in chunks_with_delimiter:
+        statement += chunk
 
         if sqlite3.complete_statement(statement):
             statements.append(statement.strip())


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/71351

@DeadlySin2 @Frank3501 @wolfgangpurrer I've created a tool to recover your `zigbee.db` and skip the broken rows that are preventing ZHA from properly migrating your database.

You will need a Python environment to install this package, along with access to `sqlite3`. macOS and Linux are preferable but you can probably find a pre-compiled SQLite binary for Windows if that's all you have available.

Here are some installation instructions for getting a Python virtual environment set up on every common platform: https://github.com/zigpy/zigpy-znp/blob/dev/TOOLS.md#table-of-contents. Ignore the `pip install zigpy-znp` part and instead substitute the command below:

```console
$ pip install git+https://github.com/zigpy/zigpy-cli.git
```

If you're running Home Assistant OS, you will have to run `apk add sqlite` to install the `sqlite3` utility.

You can then try recovering it:
```console
$ zigpy -v db recover /path/to/your/zigbee.db fixed.db
```

Please post your corrupted `zigbee.db` in this issue as well, I'd like to keep track of what exactly is breaking and possibly include this functionality into zigpy in the future. Thanks!