### PR TITLE
Network formation and scanning improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "click",
         "coloredlogs",
         "scapy",
-        "zigpy>=0.48.0",
+        "zigpy>=0.48.1",
         "bellows>=0.31.0",
         "zigpy-deconz>=0.18.0",
         "zigpy-znp>=0.8.0",

--- a/zigpy_cli/radio.py
+++ b/zigpy_cli/radio.py
@@ -48,7 +48,7 @@ async def radio(ctx, radio, port, baudrate=None):
 
     # Start the radio
     app_cls = radio_module.ControllerApplication
-    config = app_cls.SCHEMA({"device": {"path": port}})
+    config = app_cls.SCHEMA({"device": {"path": port}, "backup_enabled": False})
 
     if baudrate is not None:
         config["device"]["baudrate"] = baudrate


### PR DESCRIPTION
Speeds up network formation 2x on freshly-flashed radios and removes shutdown errors caused by backup task cancellation.

Also adds a `-n` flag to `energy-scan` to exit the scanning loop after a certain number of scans.