### PR TITLE
Reconstruct OTA images from PCAP files

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ $ zigpy ota generate-index --ota-url-root="https://example.org/fw" path/to/firmw
 ...
 ```
 
+## Reconstruct an OTA image from a series of packet captures
+
+Requires the `tshark` binary to be available.
+
+```console
+$ zigpy ota reconstruct-from-pcaps --add-network-key aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99 --output-root ./extracted/ *.pcap
+Constructing image type=0x298b, version=0x00000005, manuf_code=0x115f: 157424 bytes
+2023-02-22 03:39:51.406 ubuntu zigpy_cli.ota ERROR Missing 48 bytes starting at offset 0x0000ADA0: filling with 0xAB
+2023-02-22 03:39:51.406 ubuntu zigpy_cli.ota ERROR Missing 48 bytes starting at offset 0x000106B0: filling with 0xAB
+Constructing image type=0x298b, version=0x00000009, manuf_code=0x115f: 163136 bytes
+```
+
+
 # PCAP
 ## Re-calculate the FCS on a packet capture
 

--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -145,6 +145,14 @@ def generate_index(ctx, ota_url_root, output, files):
 @click.argument("files", nargs=-1, type=pathlib.Path)
 def reconstruct_from_pcaps(ctx, network_keys, fill_byte, output_root, files):
     packets = []
+
+    network_keys = [
+        # ZigBeeAlliance09
+        t.KeyData.convert("5A:69:67:42:65:65:41:6C:6C:69:61:6E:63:65:30:39"),
+        # Z2M default
+        t.KeyData.convert("01:03:05:07:09:0B:0D:0F:00:02:04:06:08:0A:0C:0D"),
+    ] + list(network_keys)
+
     keys = "\n".join(
         [f'"{k}","Normal","Network Key {i + 1}"' for i, k in enumerate(network_keys)]
     )

--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -258,11 +258,12 @@ def reconstruct_from_pcaps(ctx, network_keys, fill_byte, output_root, files):
             )
             buffer[start : start + count] = [fill_byte] * count
 
+        filename = output_root / (
+            f"ota_t{image_type}_m{image_manuf_code}_v{image_version}"
+            f"{'_partial' if missing_ranges else ''}.ota"
+        )
+
         output_root.mkdir(exist_ok=True)
-        (
-            output_root
-            / (
-                f"ota_t{image_type}_m{image_manuf_code}_v{image_version}"
-                f"{'_partial' if missing_ranges else ''}.ota"
-            )
-        ).write_bytes(bytes(buffer))
+        filename.write_bytes(bytes(buffer))
+
+        info.callback([filename])

--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -141,7 +141,7 @@ def generate_index(ctx, ota_url_root, output, files):
     required=True,
 )
 @click.argument("files", nargs=-1, type=pathlib.Path)
-def extract_pcap_ota(ctx, network_key, fill_byte, output_root, files):
+def reconstruct_from_pcaps(ctx, network_key, fill_byte, output_root, files):
     packets = []
 
     for f in files:

--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -219,6 +219,17 @@ def reconstruct_from_pcaps(ctx, network_key, fill_byte, output_root, files):
         buffer = [None] * image_size
 
         for offset, chunk in sorted(ota_chunks[image_key]):
+            current_value = buffer[offset : offset + len(chunk)]
+
+            if (
+                all(c is not None for c in buffer[offset : offset + len(chunk)])
+                and current_value != chunk
+            ):
+                LOGGER.error(
+                    f"Inconsistent {len(chunk)} bytes starting at offset"
+                    f" 0x{offset:08X}: was {current_value}, now {chunk}"
+                )
+
             buffer[offset : offset + len(chunk)] = chunk
 
         missing_indices = [o for o, v in enumerate(buffer) if v is None]

--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -133,7 +133,9 @@ def generate_index(ctx, ota_url_root, output, files):
 
 @ota.command()
 @click.pass_context
-@click.option("--network-key", type=t.KeyData.convert, required=True)
+@click.option(
+    "--add-network-key", "network_keys", type=t.KeyData.convert, multiple=True
+)
 @click.option("--fill-byte", type=HEX_OR_DEC_INT, default=0xAB)
 @click.option(
     "--output-root",
@@ -141,15 +143,18 @@ def generate_index(ctx, ota_url_root, output, files):
     required=True,
 )
 @click.argument("files", nargs=-1, type=pathlib.Path)
-def reconstruct_from_pcaps(ctx, network_key, fill_byte, output_root, files):
+def reconstruct_from_pcaps(ctx, network_keys, fill_byte, output_root, files):
     packets = []
+    keys = "\n".join(
+        [f'"{k}","Normal","Network Key {i + 1}"' for i, k in enumerate(network_keys)]
+    )
 
     for f in files:
         proc = subprocess.run(
             [
                 "tshark",
                 "-o",
-                f'uat:zigbee_pc_keys:"{network_key}","Normal","Network Key"',
+                f"uat:zigbee_pc_keys:{keys}",
                 "-r",
                 str(f),
                 "-T",

--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -178,33 +178,20 @@ def reconstruct_from_pcaps(ctx, network_key, fill_byte, output_root, files):
             .get("zbee_zcl_general.ota.status")
             == "0x00"
         ):
-            packet["zbee_nwk"]["zbee_nwk.dst"]
-
-            image_version = packet["zbee_zcl"]["Payload"][
-                "zbee_zcl_general.ota.file.version"
-            ]
-            image_type = packet["zbee_zcl"]["Payload"][
-                "zbee_zcl_general.ota.image.type"
-            ]
-            image_manuf_code = packet["zbee_zcl"]["Payload"][
-                "zbee_zcl_general.ota.manufacturer_code"
-            ]
+            zcl = packet["zbee_zcl"]["Payload"]
+            image_version = zcl["zbee_zcl_general.ota.file.version"]
+            image_type = zcl["zbee_zcl_general.ota.image.type"]
+            image_manuf_code = zcl["zbee_zcl_general.ota.manufacturer_code"]
 
             image_key = (image_version, image_type, image_manuf_code)
 
-            if "zbee_zcl_general.ota.image.size" in packet["zbee_zcl"]["Payload"]:
-                image_size = int(
-                    packet["zbee_zcl"]["Payload"]["zbee_zcl_general.ota.image.size"]
-                )
+            if "zbee_zcl_general.ota.image.size" in zcl:
+                image_size = int(zcl["zbee_zcl_general.ota.image.size"])
                 ota_sizes[image_key] = image_size
-            elif "zbee_zcl_general.ota.image.data" in packet["zbee_zcl"]["Payload"]:
-                offset = int(
-                    packet["zbee_zcl"]["Payload"]["zbee_zcl_general.ota.file.offset"]
-                )
+            elif "zbee_zcl_general.ota.image.data" in zcl:
+                offset = int(zcl["zbee_zcl_general.ota.file.offset"])
                 data = bytes.fromhex(
-                    packet["zbee_zcl"]["Payload"][
-                        "zbee_zcl_general.ota.image.data"
-                    ].replace(":", "")
+                    zcl["zbee_zcl_general.ota.image.data"].replace(":", "")
                 )
 
                 ota_chunks[image_key].add((offset, data))


### PR DESCRIPTION
This is a (hacky and WIP) tool to reconstruct Zigbee OTA images from raw traffic. It combines blocks in any order from multiple independent PCAPs.

There's unfortunately no simple, pure-Python way to parse PCAP files so it relies on Wireshark's `tshark` executable to be available in the `PATH`. Sample usage:

```console
$ zigpy ota reconstruct-from-pcaps --add-network-key aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99 --output-root ./extracted/ *.pcap
Constructing image type=0x298b, version=0x00000005, manuf_code=0x115f: 157424 bytes
2023-02-22 03:39:51.406 ubuntu zigpy_cli.ota ERROR Missing 48 bytes starting at offset 0x0000ADA0: filling with 0xAB
2023-02-22 03:39:51.406 ubuntu zigpy_cli.ota ERROR Missing 48 bytes starting at offset 0x000106B0: filling with 0xAB
Constructing image type=0x298b, version=0x00000009, manuf_code=0x115f: 163136 bytes
```

It will generate OTA files that correspond to every detected image:

```console
$ ls extracted
ota_t0x298b_m0x115f_v0x00000005_partial.ota
ota_t0x298b_m0x115f_v0x00000009.ota
```

Hardware-specific images aren't currently supported.

CC: @TheJulianJES