### PR TITLE
Switch to `setuptools-git-versioning`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,12 +14,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
-    - name: Set package version
-      run: |
-        version="${{ github.event.release.tag_name }}"
-        version="${version,,}"  # lowercase it
-        version="${version#v}"  # remove `v`
-        sed -i "s/version = \"0\.0\.0\"/version = \"${version}\"/" pyproject.toml
     - name: Install wheel
       run: >-
         pip install wheel build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning<2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "zigpy-cli"
-version = "0.0.0"
+dynamic = ["version"]
 description = "Unified command line interface for zigpy radios"
 urls = {repository = "https://github.com/zigpy/zigpy-cli"}
 authors = [
@@ -36,6 +36,9 @@ testing = [
     "pytest-mock>=3.8.2",
     "pytest-cov>=3.0.0",
 ]
+
+[tool.setuptools-git-versioning]
+enabled = true
 
 [project.scripts]
 zigpy = "zigpy_cli.__main__:cli"


### PR DESCRIPTION
Allows for automatic versioning for the generated wheel, source distributions, and installing straight from the Git repo. The current approach doesn't handle the last two use cases properly.