### PR TITLE
Add zboss support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "bellows>=0.35.1",
     "zigpy-deconz>=0.21.0",
     "zigpy-xbee>=0.18.0",
+    "zigpy-zboss>=1.1.0",
     "zigpy-zigate>=0.11.0",
     "zigpy-znp>=0.11.1"
 ]

--- a/zigpy_cli/const.py
+++ b/zigpy_cli/const.py
@@ -47,6 +47,16 @@ RADIO_LOGGING_CONFIGS = {
             "zigpy_xbee.api": logging.DEBUG,
         },
     ],
+    "zboss": [
+        {
+            "zigpy_zboss.zigbee.application": logging.INFO,
+            "zigpy_zboss.api": logging.INFO,
+        },
+        {
+            "zigpy_zboss.zigbee.application": logging.DEBUG,
+            "zigpy_zboss.api": logging.DEBUG,
+        },
+    ],
     "zigate": [
         {
             "zigpy_zigate": logging.INFO,


### PR DESCRIPTION
Add support for nRF52840 dongle that is using the ZBOSS NCP solution. It will probably work for other HW dongle using the ZBOSS NCP interface.
See https://github.com/kardia-as/zigpy-zboss

Closes #5 