### PR TITLE
Add zigpy_zboss to the RADIO_TO_PACKAGE map

### DIFF
--- a/zigpy_cli/const.py
+++ b/zigpy_cli/const.py
@@ -11,7 +11,7 @@ RADIO_TO_PACKAGE = {
     "ezsp": "bellows",
     "deconz": "zigpy_deconz",
     "xbee": "zigpy_xbee",
-    "zboss" : "zigpy_zboss",
+    "zboss": "zigpy_zboss",
     "zigate": "zigpy_zigate",
     "znp": "zigpy_znp",
 }

--- a/zigpy_cli/const.py
+++ b/zigpy_cli/const.py
@@ -11,6 +11,7 @@ RADIO_TO_PACKAGE = {
     "ezsp": "bellows",
     "deconz": "zigpy_deconz",
     "xbee": "zigpy_xbee",
+    "zboss" : "zigpy_zboss",
     "zigate": "zigpy_zigate",
     "znp": "zigpy_znp",
 }


### PR DESCRIPTION
You can't use the Zboss radios without this entry. With it, I've had success using the various commands with an nrf52840 dongle through zboss.