### PR TITLE
Advanced energy scan

### DIFF
--- a/zigpy_cli/radio.py
+++ b/zigpy_cli/radio.py
@@ -279,6 +279,25 @@ async def advanced_energy_scan(app, output, num_scans, randomize):
             timestamp = time.time()
             output.write(f"{timestamp:0.4f},{channel},{energy:0.4f}\n")
 
+    import bellows.types
+    from bellows.zigbee.application import (
+        ControllerApplication as EzspControllerApplication,
+    )
+
+    if not isinstance(app, EzspControllerApplication):
+        return
+
+    await asyncio.sleep(1)
+    for channel in channels:
+        networks = await app._ezsp.startScan(
+            scanType=bellows.types.EzspNetworkScanType.ACTIVE_SCAN,
+            channelMask=zigpy.types.Channels.from_channel_list([channel]),
+            duration=6,
+        )
+
+        for network, lqi, rssi in networks:
+            print(f"Found network {network}: LQI={lqi}, RSSI={rssi}")
+
 
 @radio.command()
 @click.pass_obj

--- a/zigpy_cli/radio.py
+++ b/zigpy_cli/radio.py
@@ -253,6 +253,7 @@ async def advanced_energy_scan(
     scan_counts = {channel: num_energy_scans for channel in channels}
 
     scan_data = {
+        "current_channel": app.state.network_info.channel,
         "energy_scan": [],
         "network_scan": [],
     }
@@ -302,7 +303,10 @@ async def advanced_energy_scan(
                 }
             )
 
-    await asyncio.sleep(1)
+    if not isinstance(app, EzspControllerApplication):
+        json.dump(scan_data, output, separators=(",", ":"))
+        return
+
     for channel in channels:
         networks = set()
 
@@ -329,10 +333,11 @@ async def advanced_energy_scan(
                         "channel": channel,
                         "lqi": lqi,
                         "rssi": rssi,
-                        "network": {
-                            **network.as_dict(),
-                            "extendedPanId": str(network.extendedPanId),
-                        },
+                        "allowing_join": network.allowingJoin,
+                        "extended_pan_id": str(network.extendedPanId),
+                        "nwk_update_id": network.nwkUpdateId,
+                        "pan_id": network.panId,
+                        "stack_profile": network.stackProfile,
                     }
                 )
 


### PR DESCRIPTION
To run it:

```bash
# Collect the data
pip install 'git+https://github.com/puddly/zigpy-cli@puddly/advanced-energy-scan'
zigpy radio ezsp /dev/cu.SLAB_USBtoUART advanced-energy-scan \
    --num-energy-scans 1000 \
    --num-network-scans 20 \
    advanced-energy-scan.json

# Plot it with the script below
pip install pandas matplotlib
python plot.py advanced-energy-scan.json
```

---

Inspired by https://github.com/zigpy/zha/issues/51.

I'm thinking of taking a slightly different approach to pick channels. Instead of performing a "long" scan with a high exponent, we instead perform many short scans. The theory is that the one long scan is just `max(short_scans)` for the same time period so we're just discarding data.

This allows for a much more granular view of the spectrum that can be combined with a beacon scan to identify *real* noise as opposed to a Zigbee router right next to the coordinator:

![advanced-energy-scan](https://github.com/user-attachments/assets/aaedc7c5-47ce-44bc-b901-4d074962ad33)


Script to generate the above plot:

```python
import sys
import json
import pathlib
import pandas as pd
import matplotlib.pyplot as plt
import matplotlib.patches as patches

path = pathlib.Path(sys.argv[1])
data = json.loads(path.read_text())

current_channel = data["current_channel"]
energy_scan = pd.DataFrame(data=data["energy_scan"])
energy_scan.timestamp = pd.to_datetime(energy_scan.timestamp, unit="s")

network_scan = pd.DataFrame(data["network_scan"])

if energy_scan.rssi.isna().any():
    # LQI only scan
    vmin = 0
    vmax = 255
    energy_scan["scan"] = energy_scan.energy
    scan_type = "lqi"
else:
    # Scan with RSSI
    vmin = -100
    vmax = 10
    energy_scan["scan"] = energy_scan.rssi
    scan_type = "rssi"

# Define the colormap for histograms
plt.rcParams["figure.dpi"] = 50
energy_cmap = plt.get_cmap("viridis")
network_cmap = plt.get_cmap("hsv")
norm = plt.Normalize(vmin=vmin, vmax=vmax)

# Set up the plot
num_channels = len(energy_scan.channel.drop_duplicates().sort_values().to_list())
fig, axes = plt.subplots(nrows=num_channels, figsize=(10, 20), sharex=True)
fig.suptitle(
    (
        "Energy Distribution Across 802.15.4 Channels"
        + f" ({len(energy_scan) // num_channels} samples)\n"
        + path.name
    ),
    fontsize=20,
)

for ax, ((channel,), scans) in zip(axes, energy_scan.groupby(["channel"])):
    counts, bins, hist_patches = ax.hist(
        scans["scan"],
        bins=100,
        range=(vmin, vmax),
        color="black",
        edgecolor="black",
    )

    for patch, bin_left in zip(hist_patches, bins):
        patch.set_facecolor(energy_cmap(norm(bin_left)))

    networks = None

    if not network_scan.empty:
        networks = network_scan[network_scan.channel == channel].copy()

        # Draw vertical lines according to each network beacon, colored by extended_pan_id
        if not networks.empty:
            network_indexes = pd.factorize(networks.extended_pan_id)[0]
            networks["color"] = network_indexes / (network_indexes.max() + 1)

            for _, network in networks.iterrows():
                ax.axvline(
                    (network.rssi if scan_type == "rssi" else network.lqi),
                    color=network_cmap(network.color),
                    linestyle="dotted",
                    linewidth=3,
                    alpha=0.5,
                    zorder=0,
                )

    title = "$\\bf{" + f"Channel\\ {channel}" + "}$"

    if networks is not None and not networks.empty:
        title += f"\n{len(networks)} networks"

    ax.set_frame_on(False)

    ax.set_ylabel(title, rotation=0)
    ax.set_ylim(0, None)
    ax.set_xlim(vmin, vmax)

    ax.yaxis.set_label_coords(-0.1, 0.4)
    ax.yaxis.set_ticks([])

    # Show the x axis on the last channel
    if channel == 26:
        ax.set_xlabel("RSSI (dBm)" if scan_type == "rssi" else "LQI")
    else:
        ax.xaxis.set_visible(False)

    # Highlight the plot for the current channel
    if channel == current_channel:
        ax.set_facecolor("lightblue")

plt.tight_layout()
plt.savefig(f"{path.stem}.png", dpi=200)
plt.show()
```