### PR TITLE
Expose flow_control paramater from zigpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ radio requires exclusive access to the hardware: if both are running at once, ne
 Network commands require the radio type to be specified. See `zigpy radio --help` for the list of supported types.
 If your radio requires a different baudrate than the radio library default (mainly EZSP), you must specify it as a command line option. For example, `zigpy radio --baudrate 115200 ezsp backup -`.
 
+Similarly if a different flow control is required ("hardware" or "software"), this also must be specified, otherwise the driver default will be used (usually software flow control). For example, `zigpy radio --flow-control hardware znp backup -`.
+
 ## Network backup
 
 ```console

--- a/zigpy_cli/radio.py
+++ b/zigpy_cli/radio.py
@@ -25,9 +25,10 @@ LOGGER = logging.getLogger(__name__)
 @click.argument("radio", type=click.Choice(list(RADIO_TO_PACKAGE.keys())))
 @click.argument("port", type=str)
 @click.option("--baudrate", type=int, default=None)
+@click.option("--flow-control", type=click.Choice(["software", "hardware", "none"]), default=None)
 @click.option("--database", type=str, default=None)
 @click_coroutine
-async def radio(ctx, radio, port, baudrate=None, database=None):
+async def radio(ctx, radio, port, baudrate=None, flow_control=None, database=None):
     # Setup logging for the radio
     verbose = ctx.parent.params["verbose"]
     logging_configs = RADIO_LOGGING_CONFIGS[radio]
@@ -59,6 +60,9 @@ async def radio(ctx, radio, port, baudrate=None, database=None):
 
     if baudrate is not None:
         config["device"]["baudrate"] = baudrate
+
+    if flow_control == "hardware" or flow_control == "software":
+        config["device"]["flow_control"] = flow_control
 
     app = radio_module.ControllerApplication(config)
 


### PR DESCRIPTION
Certain boards (such as the Sonoff Zigbee 3.0 USB Dongle Plus P) have a hardware switch that allows for turning on hardware flow control (given the correct firmware is flashed). This requires of course that zigpy-cli also allows for setting this flag to be able to communicate with the dongle.

Zigpy and zigpy-znp already support hardware flow control fully. No wit is time that zigpy-cli also offers this option.