### PR TITLE
Network scanning interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "coloredlogs",
     "scapy",
-    "zigpy>=0.55.0",
+    "zigpy>=0.75.0",
     "bellows>=0.43.0",
     "zigpy-deconz>=0.21.0",
     "zigpy-xbee>=0.18.0",


### PR DESCRIPTION
Implements https://github.com/zigpy/zigpy/pull/1461. As usual, only supported by EmberZNet.

zigpy-znp technically implements this interface but it requires NVRAM modification and cannot be called without fully shutting down the stack.