### PR TITLE
Add `file_size` to OTA index

### DIFF
--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -126,6 +126,7 @@ def generate_index(ctx, ota_url_root, output, files):
         metadata = {
             "binary_url": url,
             "file_version": image.header.file_version,
+            "file_size": len(contents),
             "image_type": image.header.image_type,
             "manufacturer_id": image.header.manufacturer_id,
             "changelog": "",


### PR DESCRIPTION
This adds `file_size` to OTA index generation, as it's required by zigpy since a year or so.