### PR TITLE
Drop old `PYTHON_VERSION_DEFAULT` from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       CODE_FOLDER: zigpy_cli
       CACHE_VERSION: 3
       PRE_COMMIT_CACHE_PATH: ~/.cache/pre-commit
-      PYTHON_VERSION_DEFAULT: 3.9.15
       MINIMUM_COVERAGE_PERCENTAGE: 1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This fixes CI. Default is 3.11.14 in workflows repo.