### PR TITLE
Fix index generation not wrapping list in `firmwares`

### DIFF
--- a/zigpy_cli/ota.py
+++ b/zigpy_cli/ota.py
@@ -140,7 +140,7 @@ def generate_index(ctx, ota_url_root, output, files):
         LOGGER.info("Writing %s", f)
         ota_metadata.append(metadata)
 
-    json.dump(ota_metadata, output, indent=4)
+    json.dump({"firmwares": ota_metadata}, output, indent=4)
     output.write("\n")
 
 


### PR DESCRIPTION
It has been reported that zigpy-cli still does not generate valid zigpy indexes.
We need to wrap the firmware list in `firmwares` (in a dict), see the schema: [zigpy/ota/json_schemas.py#L260](https://github.com/zigpy/zigpy/blob/7c805e0e2b2c8131bc4d77b4b529f4d87e24bc7d/zigpy/ota/json_schemas.py#L260)

This requirement seems to exist since quite a while, possibly introduced with the big OTA v2 PR:
- https://github.com/zigpy/zigpy/pull/1340