### PR TITLE
Support recent zigpy and Python 3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ ENV/
 TI Z-Stack/
 
 zigpy-znp-*.*.*/
+# uv
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "bellows>=0.47.0",
     "zigpy-deconz>=0.25.0",
     "zigpy-xbee>=0.21.0",
-    "zigpy-zboss>=1.2.0",
     "zigpy-zigate>=0.14.0",
     "zigpy-znp>=1.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,20 @@ dependencies = [
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]
 
-[project.optional-dependencies]
+[dependency-groups]
 testing = [
-    "pytest>=7.1.2",
-    "pytest-asyncio>=0.19.0",
-    "pytest-timeout>=2.1.0",
-    "pytest-mock>=3.8.2",
-    "pytest-cov>=3.0.0",
+    "coverage[toml]>=7.0",
+    "pre-commit>=3.5",
+    "pytest>=8.4",
+    "pytest-asyncio>=1.0",
+    "pytest-cov>=5.0",
+    "pytest-mock>=3.14",
+    "pytest-timeout>=2.3",
+]
+ci = [
+    {include-group = "testing"},
+    "pytest-github-actions-annotate-failures>=0.2",
+    "pytest-xdist>=3.5",
 ]
 
 [tool.setuptools-git-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
     "click>=8.1",
     "coloredlogs>=15.0",
     "scapy>=2.5.0",
-    "zigpy>=0.85.0",
+    "zigpy>=2.0.0",
     "bellows>=0.47.0",
     "zigpy-deconz>=0.25.0",
-    "zigpy-xbee>=0.21.0",
+    "zigpy-xbee>=0.22.0",
     "zigpy-zigate>=0.14.0",
     "zigpy-znp>=1.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,18 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "GPL-3.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
-    "click",
-    "coloredlogs",
-    "scapy",
-    "zigpy>=0.75.0",
-    "bellows>=0.43.0",
-    "zigpy-deconz>=0.21.0",
-    "zigpy-xbee>=0.18.0",
-    "zigpy-zboss>=1.1.0",
-    "zigpy-zigate>=0.11.0",
-    "zigpy-znp>=0.11.1"
+    "click>=8.1",
+    "coloredlogs>=15.0",
+    "scapy>=2.5.0",
+    "zigpy>=0.85.0",
+    "bellows>=0.47.0",
+    "zigpy-deconz>=0.25.0",
+    "zigpy-xbee>=0.21.0",
+    "zigpy-zboss>=1.2.0",
+    "zigpy-zigate>=0.14.0",
+    "zigpy-znp>=1.0.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ ci = [
     "pytest-xdist>=3.5",
 ]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
 [tool.setuptools-git-versioning]
 enabled = true
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,0 @@
-coverage[toml]
-pytest
-pytest-asyncio
-pytest-cov
-pytest-timeout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,3 +60,16 @@ def test_get_or_create_event_loop_replaces_closed_loop():
 
     assert new_loop is not loop
     assert not new_loop.is_closed()
+
+
+def test_get_or_create_event_loop_reregisters_cleared_loop():
+    """The loop stays registered as current even if something else clears it.
+
+    Radio libraries call `asyncio.get_event_loop()` at runtime, which fails on
+    Python 3.14 when no loop is set.
+    """
+    loop = get_or_create_event_loop()
+    asyncio.set_event_loop(None)
+
+    assert get_or_create_event_loop() is loop
+    assert asyncio.get_event_loop() is loop

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,62 @@
+import asyncio
+
+import pytest
+
+from zigpy_cli import cli as cli_module
+from zigpy_cli.cli import click_coroutine, get_or_create_event_loop
+
+
+@pytest.fixture(autouse=True)
+def reset_loop():
+    """Keep the module-level loop from leaking between tests."""
+    old_loop = cli_module._LOOP
+    cli_module._LOOP = None
+
+    yield
+
+    if cli_module._LOOP is not None and not cli_module._LOOP.is_closed():
+        cli_module._LOOP.close()
+
+    cli_module._LOOP = old_loop
+    asyncio.set_event_loop(None)
+
+
+def test_click_coroutine_without_running_loop():
+    """`click_coroutine` works when no event loop exists yet.
+
+    Python 3.14's `asyncio.get_event_loop()` raises instead of creating one.
+    """
+    asyncio.set_event_loop(None)
+
+    @click_coroutine
+    async def cmd(value):
+        await asyncio.sleep(0)
+        return value * 2
+
+    assert cmd(21) == 42
+
+
+def test_click_coroutine_reuses_the_same_loop():
+    """All callbacks must share a loop: the group creates the app, the
+    subcommand uses it, and the cleanup callback shuts it down."""
+    loops = []
+
+    @click_coroutine
+    async def cmd():
+        loops.append(asyncio.get_running_loop())
+
+    cmd()
+    cmd()
+
+    assert loops[0] is loops[1]
+    assert loops[0] is get_or_create_event_loop()
+
+
+def test_get_or_create_event_loop_replaces_closed_loop():
+    loop = get_or_create_event_loop()
+    loop.close()
+
+    new_loop = get_or_create_event_loop()
+
+    assert new_loop is not loop
+    assert not new_loop.is_closed()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,15 +9,15 @@ from zigpy_cli.cli import click_coroutine, get_or_create_event_loop
 @pytest.fixture(autouse=True)
 def reset_loop():
     """Keep the module-level loop from leaking between tests."""
-    old_loop = cli_module._LOOP
     cli_module._LOOP = None
+    asyncio.set_event_loop(None)
 
     yield
 
     if cli_module._LOOP is not None and not cli_module._LOOP.is_closed():
         cli_module._LOOP.close()
 
-    cli_module._LOOP = old_loop
+    cli_module._LOOP = None
     asyncio.set_event_loop(None)
 
 

--- a/zigpy_cli/cli.py
+++ b/zigpy_cli/cli.py
@@ -13,10 +13,29 @@ LOGGER = logging.getLogger(__name__)
 ROOT_LOGGER = logging.getLogger()
 
 
+_LOOP: asyncio.AbstractEventLoop | None = None
+
+
+def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
+    """Return the shared event loop, creating it on first use.
+
+    Every coroutine callback has to run on the *same* loop: the `radio` group
+    callback creates the `ControllerApplication`, the subcommand then uses it, and
+    `radio_cleanup` shuts it down when the context closes.
+    """
+    global _LOOP
+
+    if _LOOP is None or _LOOP.is_closed():
+        _LOOP = asyncio.new_event_loop()
+        asyncio.set_event_loop(_LOOP)
+
+    return _LOOP
+
+
 def click_coroutine(cmd):
     @functools.wraps(cmd)
     def inner(*args, **kwargs):
-        loop = asyncio.get_event_loop()
+        loop = get_or_create_event_loop()
         return loop.run_until_complete(cmd(*args, **kwargs))
 
     return inner

--- a/zigpy_cli/cli.py
+++ b/zigpy_cli/cli.py
@@ -27,7 +27,11 @@ def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
 
     if _LOOP is None or _LOOP.is_closed():
         _LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_LOOP)
+
+    # Re-register every time: radio libraries call `asyncio.get_event_loop()` at
+    # runtime, so the loop has to stay the thread's current one even if something
+    # else cleared it in the meantime.
+    asyncio.set_event_loop(_LOOP)
 
     return _LOOP
 

--- a/zigpy_cli/const.py
+++ b/zigpy_cli/const.py
@@ -11,7 +11,6 @@ RADIO_TO_PACKAGE = {
     "ezsp": "bellows",
     "deconz": "zigpy_deconz",
     "xbee": "zigpy_xbee",
-    "zboss": "zigpy_zboss",
     "zigate": "zigpy_zigate",
     "znp": "zigpy_znp",
 }
@@ -46,16 +45,6 @@ RADIO_LOGGING_CONFIGS = {
         {
             "zigpy_xbee.zigbee.application": logging.DEBUG,
             "zigpy_xbee.api": logging.DEBUG,
-        },
-    ],
-    "zboss": [
-        {
-            "zigpy_zboss.zigbee.application": logging.INFO,
-            "zigpy_zboss.api": logging.INFO,
-        },
-        {
-            "zigpy_zboss.zigbee.application": logging.DEBUG,
-            "zigpy_zboss.api": logging.DEBUG,
         },
     ],
     "zigate": [

--- a/zigpy_cli/radio.py
+++ b/zigpy_cli/radio.py
@@ -11,10 +11,8 @@ import random
 import sys
 
 import click
-import zigpy.state
+import zigpy.backups
 import zigpy.types
-import zigpy.zdo
-import zigpy.zdo.types
 from zigpy.application import ControllerApplication
 
 from zigpy_cli.cli import cli, click_coroutine


### PR DESCRIPTION
Brings zigpy-cli up to date with recent zigpy (2.1.0) and the 3.11–3.14 Python matrix. `zigpy radio` was completely broken on Python 3.14, and `uv sync` failed outright, so this fixes both along with the packaging metadata that had drifted out of date.

## Every `zigpy radio ...` command crashed on Python 3.14

`click_coroutine` called `asyncio.get_event_loop()` from a sync context. As of Python 3.14 that raises instead of creating a loop, so every async command died before doing anything:

```
File "zigpy_cli/cli.py", line 19, in inner
    loop = asyncio.get_event_loop()
RuntimeError: There is no current event loop in thread 'MainThread'.
```

The loop is now created explicitly. It has to be a single shared loop rather than a per-invocation `asyncio.run()`, because the work is split across three callbacks: the `radio` group callback constructs the `ControllerApplication`, the subcommand awaits `connect()` on it, and `radio_cleanup` (registered via `ctx.call_on_close`) later awaits `shutdown()`. `connect()` creates the transport and background tasks on whichever loop is running at the time, and `shutdown()` has to tear them down on that same loop.

`asyncio.set_event_loop()` is called on every lookup rather than only when the loop is created. The concrete reason is that `asyncio.run()` clears the thread's current-loop registration when it exits, so a create-only registration could be left stale for the rest of the process; re-registering is idempotent and self-heals. Radio libraries do call `asyncio.get_event_loop()` at runtime (`bellows/uart.py`, `zigpy_deconz/api.py`), though those particular calls happen inside a running loop, where the running loop takes precedence — so this is defensive rather than a fix for an observed crash.

## `zigpy.backups` was used without being imported

`radio restore` calls `zigpy.backups.NetworkBackup.from_dict()`, but `radio.py` never imported `zigpy.backups` — it only resolved because `zigpy.application` happens to import it. Now imported directly.

`zigpy.state`, `zigpy.zdo` and `zigpy.zdo.types` were imported but unused, and are dropped. Ruff could not flag either problem: those imports only bind the name `zigpy`, which is what hid the missing import in the first place.

## Packaging metadata

- **`requires-python` was `>=3.8`**, which was already false. zigpy has required 3.11 since 0.85.0, and `radio.py` uses `asyncio.TaskGroup` (3.11+). It also made `uv sync` fail, since uv resolves across the whole declared range — the resolver names the `>=3.8` range and zigpy's `>=3.11` as the conflict. Now `>=3.11`.
- **Dependency floors were stale enough to resolve to broken packages.** `uv lock --resolution lowest-direct` picked radio libraries predating the zigpy APIs in use, and unpinned `scapy` resolved to 2.3.1 — a Python 2-era release that fails to build (`os.chmod(fname,0755)`). Floors are now set to releases that work with recent zigpy on 3.11+; all five radio libraries were checked to import at their declared floors.
- **Test requirements moved to `[dependency-groups]`** (`testing` + `ci`), matching zigpy, and `requirements_test.txt` is removed. The shared CI workflow tries `uv sync --group ci` first and only falls back to `requirements_test.txt`; the fallback also installed `pre-commit`, `pytest-xdist` and `pytest-github-actions-annotate-failures` itself, so those had to move into the groups or the pre-commit job and the `-n auto` pytest runs would break once the modern path is taken. The test floors were stale too — `pytest` 7.1.2 uses `ast.Str`, removed in Python 3.14, so resolving at the declared floors could not run on the 3.14 matrix entry at all. (CI itself was not broken by this, since the fallback installed `pytest` unpinned.)
- **`uv.lock` is gitignored** rather than committed, matching zigpy.

## Breaking changes

- **Python 3.8–3.10 are no longer supported.** 3.8 already could not install at all — the previous `zigpy>=0.75.0` floor itself required 3.9+. On 3.9/3.10 the CLI could only ever pair with zigpy ≤0.84, and `radio packet-capture` already required 3.11 (`asyncio.TaskGroup`).
- **The `testing` extra is gone.** Dependency groups are not extras, so `pip install zigpy-cli[testing]` no longer installs test dependencies — use `uv sync --group testing`, or pip 25.1+ `--group`. Nothing in the repo or CI referenced the extra.
- **zigpy-zboss support is removed**, below.

## zigpy-zboss support removed

zigpy-zboss 2.x pins `zigpy<2`, so depending on it held the whole install back: the resolver had to fall to zboss 1.2.0 (which declares an unbounded `zigpy>=0.60.2`) to allow a recent zigpy, and 1.2.0 emits deprecation warnings against it. Dropped for now — happy to restore it once the cap upstream is relaxed.

`zboss` is no longer a valid `radio` argument, so it now fails on the `click.Choice` with the list of supported radios.

## `zigpy radio xbee` needed zigpy-xbee 0.22.0

zigpy moved the quirks API out of the library (zigpy#1846), leaving `zigpy.quirks` as a shim that forwards to `zhaquirks`, and zigpy-xbee still subclassed `zigpy.quirks.CustomDevice`. Any install without zha-quirks present therefore failed at import:

```
ModuleNotFoundError: No module named 'zhaquirks'
```

zigpy/zigpy-xbee#179 fixed this and shipped in zigpy-xbee 0.22.0, so the floor here is set to that release. It also fixed a `serialx` incompatibility in zigpy-xbee's baudrate setter, which `init_api_mode()` reaches only once entering AT command mode at the configured baudrate has failed and it starts scanning the other known baudrates.

0.22.0 requires `zigpy>=2.0.0`, which makes 2.0.0 the real floor for the whole project, so that is now declared directly instead of a `zigpy>=0.85.0` that no longer described anything installable.

## Testing

- Full suite and `pre-commit run --all-files` (black + ruff) pass on 3.14.
- Four tests are added for the event-loop behaviour. The two that guard the actual fixes were checked against the corresponding pre-fix code rather than only against the new code: the original `asyncio.get_event_loop()` raises on 3.14, and the create-only registration fails the re-registration test.
- Installed from a clean venv at both the declared floors (`uv sync --resolution lowest-direct`) and the latest resolvable set (zigpy 2.1.0); the suite passes on both.
- `zigpy radio znp <pty> info` and `zigpy radio xbee <pty> info` exercised against a pty: group callback, subcommand and cleanup all run on the shared loop, and the failure propagates cleanly. Both reach the radio protocol layer.
- OTA and pcap paths spot-checked against zigpy 2.1.0 — image parse/validate, index generation, firmware dump, and pcap output readable by scapy.

Not tested against real hardware — radio verification used a pty, which reaches the protocol layer but not a physical coordinator.
